### PR TITLE
PR: 라우터 URL 변경 이벤트 추가, 버그 해결을 위한 웹팩 설정

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -17,8 +17,6 @@ export default class App {
     new Layout(this.$container);
     new Router();
 
-    notify(RouterEvent.onStateChanged, {
-      path: location.pathname,
-    });
+    notify(RouterEvent.changeUrl, { path: location.pathname });
   }
 }

--- a/client/src/component/Navigator.js
+++ b/client/src/component/Navigator.js
@@ -33,13 +33,16 @@ export default class Navigator extends Component {
   }
 
   onClickTab(e) {
-    notify(RouterEvent.onStateChanged, { path: `/${e.target.dataset.name}` });
+    notify(RouterEvent.changeUrl, {
+      path: `/${e.target.dataset.name}`,
+      useCurrentData: true,
+    });
   }
 
   render() {
     const template = `
     <ul class="tab">
-      <li class="tabbed" data-name="">내역</li>
+      <li class="tabbed" data-name="record">내역</li>
       <li data-name="calendar">달력</li>
       <li data-name="statistics">통계</li>
     </ul>

--- a/client/src/constant/Event.js
+++ b/client/src/constant/Event.js
@@ -9,6 +9,7 @@ const Event = {
     onDateChanged: 'DateView:onDateChanged',
   },
   RouterEvent: {
+    changeUrl: 'Router:changeUrl',
     onStateChanged: 'Router:onStateChanged',
   },
 };

--- a/client/src/constant/constant.js
+++ b/client/src/constant/constant.js
@@ -2,6 +2,10 @@ export const SERVER = {
   API_DOMAIN: 'http://localhost:3000/api',
 };
 
+export const MESSAGE = {
+  USER_INPUT_ERROR: '요청 값이 이상합니다.',
+};
+
 export const CATEGORY = {
   INCOME: 1,
   EXPENDITURE: 0,

--- a/client/src/model/model.js
+++ b/client/src/model/model.js
@@ -2,7 +2,7 @@ import apis from '@src/model/apis.js';
 import { Store } from '@constant/Store.js';
 import { StoreEvent, RouterEvent } from '@constant/Event.js';
 import { subscribe, notify } from '@constant/State.js';
-import { CATEGORY } from '@constant/constant.js';
+import { CATEGORY, MESSAGE } from '@constant/constant.js';
 
 const customPaymentMethod = {
   4: {
@@ -39,10 +39,7 @@ export default class Model {
   }
 
   async getRecord(data) {
-    let [, , year, month] = data.path.split('/');
-    year = !year ? new Date().getFullYear() : year;
-    month = !month ? new Date().getMonth() + 1 : month;
-
+    const { year, month } = data;
     await this.setDefaultData();
     await this.setRecord(year, month);
     notify(StoreEvent.onUpdated, { ...Store });
@@ -53,6 +50,11 @@ export default class Model {
       incomeSum = 0;
 
     const data = await (await apis.findRecord({ year, month })).json();
+    if (!data.success) {
+      alert(MESSAGE.USER_INPUT_ERROR);
+      location.href = '/';
+    }
+
     Store.year = data.year;
     Store.month = data.month;
     Store.records = data.items.map((record) => {

--- a/client/src/page/MainPage.js
+++ b/client/src/page/MainPage.js
@@ -46,7 +46,11 @@ export default class MainPage {
           new RecordGroupList(),
         );
       default:
-        return div({ className: 'section' }, new AddRecordForm());
+        return div(
+          { className: 'section' },
+          new AddRecordForm(),
+          new RecordGroupList(),
+        );
     }
   }
 

--- a/client/src/page/SigninPage.js
+++ b/client/src/page/SigninPage.js
@@ -2,7 +2,7 @@ import { subscribe } from '@constant/State.js';
 import { RouterEvent } from '@constant/Event.js';
 import { div } from '@utils/defaultElement.js';
 
-export default class Signin {
+export default class SigninPage {
   constructor(container) {
     this.attribute = {
       className: 'signin_page',

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -5,7 +5,7 @@ import { Store } from '@constant/Store.js';
 export default class Router {
   constructor() {
     this.attribute = {
-      className: 'router',
+      uid: 'router',
     };
     this.applySubscribers();
     this.addPopStateListener();
@@ -21,9 +21,31 @@ export default class Router {
   applySubscribers() {
     subscribe(
       this.attribute,
+      RouterEvent.changeUrl,
+      this.onChangeUrl.bind(this),
+    );
+    subscribe(
+      this.attribute,
       RouterEvent.onStateChanged,
       this.onStateChanged.bind(this),
     );
+  }
+
+  onChangeUrl(data) {
+    let path = data.path;
+    let [, menu, year, month] = data.path.split('/');
+    year = !year ? new Date().getFullYear() : year;
+    month = !month ? new Date().getMonth() + 1 : month;
+
+    if (data.useCurrentData) {
+      const [, , currentYear, currentMonth] = location.pathname.split('/');
+      year = currentYear ? currentYear : year;
+      month = currentMonth ? currentMonth : month;
+      const menuUrl = menu ? `/${menu}/` : '';
+      path = `${menuUrl}${year}/${month}`;
+    }
+
+    notify(RouterEvent.onStateChanged, { path, menu, year, month });
   }
 
   addPopStateListener() {

--- a/client/webpack.config.common.js
+++ b/client/webpack.config.common.js
@@ -7,6 +7,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '../server/public'),
     filename: 'bundle.js',
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json', '.scss', '.css'],


### PR DESCRIPTION
> 라우터 URL 변경 이벤트 추가, 버그 해결을 위한 웹팩 설정 (publicPath)

## 체크리스트

> 작성자, 리뷰어 모두가 확인해야할 사항들 입니다.

- [o] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [o] 작성한 코드에 대해 모두 이해하였는지 확인
- [o] 관련된 label 추가했는지 확인

## 설명

### 1. [라우팅] 추가 - URL 변경 이벤트
- changeUrl 이벤트를 라우터가 Subscirbe 함.
- changeUrl 이벤트는 다른 객체에서 url 변경 요청할 때 notify 함.
  - useCurrentData 옵션을 활성화하면, menu에 대한 path만 넣어도, 요청 path와 현재 url의 year, month를 조합한다.
- 라우터는 이렇게 생성된 데이터로 onChangeEvent를 발생시킨다.

### 2. [서버] 수정 - URL Depth가 깊어지면, 스크립트 파일 못 찾는 버그
- 현재 Webpack output publicPath가 상대 경로로 지정되어 있었음.
- URL이 폴더처럼 Depth가 더 생기면, 파일을 찾지 못하는 문제점을 발견함.
- 그래서, publicPath를 절대 경로로 수정함.
