### PR TITLE
PR: 라우팅 문제 해결 (Express 정규식 적용, 이동 때 발생하는 버그) 및 리팩토링 (중복코드 제거, OR 연산자 사용)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "build-dev": "webpack --mode development",
+    "watch": "webpack --mode development --watch",
     "dev": "webpack-dev-server --open --mode development",
     "test": "jest"
   },

--- a/client/src/component/AddRecordForm.js
+++ b/client/src/component/AddRecordForm.js
@@ -1,5 +1,10 @@
 import Component from '@component/Component.js';
-import { appendChildAll, templateToElementNodes } from '@utils/document.js';
+import {
+  $,
+  appendChildAll,
+  formToDataObject,
+  templateToElementNodes,
+} from '@utils/document.js';
 
 // eslint-disable-next-line
 import style from '@stylesheet/component/AddRecordForm.scss';
@@ -20,6 +25,17 @@ export default class AddRecordForm extends Component {
   initSubscribers() {
     const subscribers = {};
     this.setSubscribers(subscribers);
+  }
+
+  componentDidMount() {
+    const $submit = $(`.${this.attribute.className} .btn_submit`);
+    $submit.addEventListener('click', this.onClickSubmit.bind(this));
+  }
+
+  onClickSubmit(e) {
+    const $form = e.target.closest(`.${this.attribute.className}`);
+    console.dir(formToDataObject($form));
+    alert('save!');
   }
 
   render() {
@@ -45,7 +61,7 @@ export default class AddRecordForm extends Component {
       <div class="item">
         <div class="title">카테고리</div>
         <div class="content">
-          <select>
+          <select name="category">
             <option value="0">선택하세요</option>
           </select>
         </div>
@@ -53,7 +69,7 @@ export default class AddRecordForm extends Component {
       <div class="item">
         <div class="title">결제수단</div>
         <div class="content">
-          <select>
+          <select name="paymentMethod">
             <option value="0">선택하세요</option>
           </select>
         </div>
@@ -63,18 +79,18 @@ export default class AddRecordForm extends Component {
       <div class="item">
         <div class="title">금액</div>
         <div class="content">
-          <input type="text">
+          <input type="text" name="amount">
         </div>
       </div>
       <div class="item">
         <div class="title">내용</div>
         <div class="content">
-          <input type="text">
+          <input type="text" name="content">
         </div>
       </div>
     </div>
     <div class="footer">
-      <button class="btn_submit">등록</button>
+      <button type="button" class="btn_submit">등록</button>
     </div>`;
 
     const innerNode = templateToElementNodes(template);

--- a/client/src/component/Calendar.js
+++ b/client/src/component/Calendar.js
@@ -7,9 +7,10 @@ import {
   chunkArray,
   formatCurrency,
 } from '@utils/helper.js';
+import { StoreEvent } from '@constant/Event.js';
+
 // eslint-disable-next-line
 import style from '@stylesheet/component/Calendar.scss';
-import { StoreEvent } from '@constant/Event.js';
 
 const DAY_IN_A_BOARD = 42;
 const WEEK_IN_A_BOARD = 7;
@@ -67,6 +68,7 @@ export default class Calendar extends Component {
       WEEK_IN_A_BOARD,
     );
   }
+
   createBoardHeader() {
     return `
       <tr class="table_header_row">

--- a/client/src/component/RecordGroupList.js
+++ b/client/src/component/RecordGroupList.js
@@ -1,7 +1,7 @@
 import Component from '@component/Component.js';
 import { StoreEvent } from '@constant/Event.js';
 import { $, appendChildAll, templateToElementNodes } from '@utils/document.js';
-import { analyzeDatetime, groupBy, numberFormat } from '@utils/helper.js';
+import { analyzeDatetime, groupBy, formatCurrency } from '@utils/helper.js';
 
 // eslint-disable-next-line
 import style from '@stylesheet/component/RecordGroupList.scss';
@@ -44,15 +44,15 @@ export default class RecordGroupList extends Component {
   createGroupSumIndicator(incomeSum, expenditureSum) {
     return `
     <div class="sum">
-      <span class="plus">+${numberFormat(incomeSum)}원</span>
-      <span class="minus">-${numberFormat(expenditureSum)}원</span>
+      <span class="plus">+${formatCurrency(incomeSum)}원</span>
+      <span class="minus">-${formatCurrency(expenditureSum)}원</span>
     </div>
     `;
   }
 
   createGroupItem(item) {
     const preAmount = item.isIncome ? '+' : '-';
-    const amount = preAmount + numberFormat(item.amount);
+    const amount = preAmount + formatCurrency(item.amount);
     return `
     <li${item.isIncome ? ' class="income"' : ''}>
       <div class="category">

--- a/client/src/constant/State.js
+++ b/client/src/constant/State.js
@@ -1,10 +1,14 @@
 import { Store } from './Store.js';
 
+const initEventState = (key) => {
+  Store.state[key] = {
+    listeners: {},
+  };
+};
+
 export const subscribe = (component, key, eventHandler) => {
   if (Store.state[key] === undefined) {
-    Store.state[key] = {
-      listeners: {},
-    };
+    initEventState(key);
   }
 
   Store.state[key].listeners[
@@ -20,18 +24,30 @@ export const notify = (key, data, targetUid = null) => {
     return;
   }
 
-  if (targetUid) {
-    Object.values(Store.state[key].listeners).some(({ eventHandler, uid }) => {
-      if (uid === targetUid) {
-        eventHandler(data);
-        return true;
-      }
+  try {
+    if (targetUid) {
+      Object.values(Store.state[key].listeners).some(
+        ({ eventHandler, uid }) => {
+          if (uid === targetUid) {
+            eventHandler(data);
+            return true;
+          }
+        },
+      );
+
+      return;
+    }
+
+    Object.values(Store.state[key].listeners).forEach(({ eventHandler }) => {
+      eventHandler(data);
     });
-
-    return;
+  } catch (err) {
+    console.error(err);
   }
+};
 
-  Object.values(Store.state[key].listeners).forEach(({ eventHandler }) => {
-    eventHandler(data);
-  });
+export const clearSubscribers = (key) => {
+  if (Store.state[key]) {
+    initEventState(key);
+  }
 };

--- a/client/src/page/MainPage.js
+++ b/client/src/page/MainPage.js
@@ -27,10 +27,10 @@ export default class MainPage {
     );
   }
 
-  onStateChanged({ path }) {
+  onStateChanged(data) {
     this.clear();
-    if (path !== '/login') {
-      this.render(path);
+    if (data.menu !== 'login') {
+      this.render(data);
     }
   }
 
@@ -38,36 +38,29 @@ export default class MainPage {
     this.$container.innerHTML = '';
   }
 
-  setComponentByPath(path) {
-    switch (path) {
-      case '/':
+  setComponentByPath(data) {
+    switch (data.menu) {
+      case '':
+      case 'record':
         return div(
           { className: 'section' },
           new AddRecordForm(),
           new RecordGroupList(),
         );
-      case '/calendar':
+      case 'calendar':
         return div({ className: 'section' }, new Calendar());
       default:
-        return div(
-          { className: 'section' },
-          new AddRecordForm(),
-          new RecordGroupList(),
-        );
+        return div({ className: 'section' });
     }
   }
 
-  render(path) {
-    setTimeout(() => {
-      notify(DateViewEvent.onDateChanged, { month: 12 });
-    }, 1000);
-
+  render(data) {
     this.$container.appendChild(
       div(
         { className: 'main_page' },
         new DateView(),
         new Navigator(),
-        this.setComponentByPath(path),
+        this.setComponentByPath(data),
       ),
     );
     notify(PageEvent.onAppendDone, {});

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -1,6 +1,5 @@
-import { subscribe, notify } from '@src/constant/State';
-import { RouterEvent } from '@src/constant/Event.js';
-import { Store } from '@constant/Store.js';
+import { subscribe, notify, clearSubscribers } from '@src/constant/State';
+import { RouterEvent, PageEvent } from '@src/constant/Event.js';
 
 export default class Router {
   constructor() {
@@ -45,6 +44,7 @@ export default class Router {
       path = `${menuUrl}${year}/${month}`;
     }
 
+    clearSubscribers(PageEvent.onAppendDone);
     notify(RouterEvent.onStateChanged, { path, menu, year, month });
   }
 

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -34,13 +34,13 @@ export default class Router {
   onChangeUrl(data) {
     let path = data.path;
     let [, menu, year, month] = data.path.split('/');
-    year = !year ? new Date().getFullYear() : year;
-    month = !month ? new Date().getMonth() + 1 : month;
+    year = year || new Date().getFullYear();
+    month = month || new Date().getMonth() + 1;
 
     if (data.useCurrentData) {
       const [, , currentYear, currentMonth] = location.pathname.split('/');
-      year = currentYear ? currentYear : year;
-      month = currentMonth ? currentMonth : month;
+      year = currentYear || year;
+      month = currentMonth || month;
       const menuUrl = menu ? `/${menu}/` : '';
       path = `${menuUrl}${year}/${month}`;
     }

--- a/client/src/utils/document.js
+++ b/client/src/utils/document.js
@@ -92,3 +92,7 @@ export const createElement = (tagName, attributes, ...childNodes) => {
 
   return element;
 };
+
+export const formToDataObject = ($form) => {
+  return Object.fromEntries(new FormData($form).entries());
+};

--- a/client/src/utils/helper.js
+++ b/client/src/utils/helper.js
@@ -1,8 +1,3 @@
-export const numberFormat = (number) => {
-  const intl = Intl.NumberFormat('en-US');
-  return intl.format(number);
-};
-
 export const getCurrentDatetime = () => {
   const date = analyzeDatetime();
   return `${date.year}-${date.month}-${date.date} ${date.hour}:${date.minute}:${date.second}`;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "money-manager",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "concurrently \"yarn --cwd ./client watch\" \"yarn --cwd ./server start\""
+  },
+  "devDependencies": {
+    "concurrently": "^5.2.0"
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 
 const indexRouter = require('@api/index');
+const frontRouter = require('./router/front');
 
 const app = express();
 
@@ -23,9 +24,7 @@ app.use(cookieParser());
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/api', indexRouter);
-app.get('/*', (req, res, next) => {
-  res.render('index.html');
-});
+app.use(frontRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/server/router/front.js
+++ b/server/router/front.js
@@ -6,9 +6,9 @@ const renderFile = (req, res, next) => {
 };
 
 router.get('/', renderFile);
-router.get('/login', renderFile);
-router.get('/list', renderFile);
-router.get('/calendar', renderFile);
-router.get('/statistics', renderFile);
+router.get('/login(/*)?', renderFile);
+router.get('/record(/*)?', renderFile);
+router.get('/calendar(/*)?', renderFile);
+router.get('/statistics(/*)?', renderFile);
 
 module.exports = router;

--- a/server/router/front.js
+++ b/server/router/front.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+
+const renderFile = (req, res, next) => {
+  res.render('index.html');
+};
+
+router.get('/', renderFile);
+router.get('/login', renderFile);
+router.get('/list', renderFile);
+router.get('/calendar', renderFile);
+router.get('/statistics', renderFile);
+
+module.exports = router;


### PR DESCRIPTION
> 라우팅 문제 해결 (Express 정규식 적용, 이동 때 발생하는 버그) 및 리팩토링 (중복코드 제거, OR 연산자 사용)

## 체크리스트

> 작성자, 리뷰어 모두가 확인해야할 사항들 입니다.

- [o] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [o] 작성한 코드에 대해 모두 이해하였는지 확인
- [o] 관련된 label 추가했는지 확인

## 설명

### 1. Express 정규식 적용
- 뎁스 상관없이 모두 index.html에 도달할 수 있도록 정규식 적용 (예시: /{menu}, /{menu}/2020)
- url규칙 (list -> record) 수정

### 2. 페이지 이동 때, 남아 있는 Subscribers로 생기는 문제 
- appendDone 이벤트 Subscribers가 페이지 이동 때 남아있어, 사라진 컴포넌트의 이벤트가 발생하는 문제가 있음.
- 일단, 라우터 ChangeUrl 이벤트 때, 해당 이벤트의 Subscribers를 리셋하는 구조로 해결했으나 다른 이벤트도 같은 이슈를 지니고 있음.
- 차후, 이동 때, 사라진 객체들이 각자 관련 있는 Subscirbers를 지우는 방식으로 해결이 필요해보임.
- 관련 이슈 : #47 

### 3. 리팩토링
- 중복된 유틸 함수 제거 (numberFormat <> formatCurrency)
- 프론트 라우터 변수 데이터 지정 (OR 연산자를 활용한 간결화)