### PR TITLE
PR: 내역 등록 (API 포함), 월 표시/이동

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "node-sass": "^4.14.1",
     "sass-loader": "^9.0.2",
     "style-loader": "^1.2.1",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "url-loader": "^4.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",

--- a/client/src/component/AddRecordForm.js
+++ b/client/src/component/AddRecordForm.js
@@ -5,6 +5,10 @@ import {
   formToDataObject,
   templateToElementNodes,
 } from '@utils/document.js';
+import { notify } from '@constant/State.js';
+import { StoreEvent, RecordEvent } from '@constant/Event.js';
+import { getCurrentDatetime } from '@utils/helper.js';
+import { CATEGORY, MESSAGE } from '@constant/constant.js';
 
 // eslint-disable-next-line
 import style from '@stylesheet/component/AddRecordForm.scss';
@@ -18,27 +22,99 @@ export default class AddRecordForm extends Component {
 
     super({ attribute });
 
+    this.state = {
+      currentGroup: CATEGORY.EXPENDITURE,
+      categories: null,
+    };
     this.initSubscribers();
     this.init();
   }
 
   initSubscribers() {
-    const subscribers = {};
+    const subscribers = {
+      [StoreEvent.onUpdated]: this.renderOptions,
+    };
     this.setSubscribers(subscribers);
   }
 
   componentDidMount() {
-    const $submit = $(`.${this.attribute.className} .btn_submit`);
+    const $submit = this.selector('.btn_submit');
     $submit.addEventListener('click', this.onClickSubmit.bind(this));
+
+    const $switchField = this.selector('.switch_field');
+    $switchField.addEventListener(
+      'change',
+      this.onChangeCategoryGroup.bind(this),
+    );
+  }
+
+  selector(selectStr) {
+    return $(`.${this.attribute.className} ${selectStr}`);
   }
 
   onClickSubmit(e) {
     const $form = e.target.closest(`.${this.attribute.className}`);
-    console.dir(formToDataObject($form));
-    alert('save!');
+    const data = formToDataObject($form);
+    let isEmpty = false;
+    Object.values(data).forEach((value) => {
+      if (value === '') {
+        isEmpty = true;
+      }
+    });
+
+    if (isEmpty) {
+      alert(MESSAGE.FORM_INPUT_EMPTY_ERROR);
+      return;
+    }
+
+    notify(RecordEvent.create, { data });
+  }
+
+  onChangeCategoryGroup(e) {
+    this.state.currentGroup = Number.parseInt(e.target.value);
+    this.renderCategoryOptions(this.state.categories);
+  }
+
+  createCategoryOptions(is_income, items) {
+    return Object.keys(items)
+      .map((key) => {
+        const item = items[key];
+        if (item.is_income === is_income) {
+          return `<option value=${key}>${item.name}</option>`;
+        }
+      })
+      .join('');
+  }
+
+  createPaymentOptions(items) {
+    return Object.keys(items)
+      .map((key) => {
+        return `<option value=${key}>${items[key].name}</option>`;
+      })
+      .join('');
+  }
+
+  renderOptions(data) {
+    this.state.categories = data.categories;
+    this.renderCategoryOptions(data.categories);
+    this.renderPaymentMethodOptions(data.paymentMethods);
+  }
+
+  renderCategoryOptions(data) {
+    const $category = this.selector('select[name=category]');
+    $category.innerHTML = this.createCategoryOptions(
+      this.state.currentGroup,
+      data,
+    );
+  }
+
+  renderPaymentMethodOptions(data) {
+    const $payment = this.selector('select[name=payment_method]');
+    $payment.innerHTML = this.createPaymentOptions(data);
   }
 
   render() {
+    const todayDate = getCurrentDatetime().slice(0, 10);
     const template = `
     <div class="block">
       <div class="item">
@@ -55,13 +131,13 @@ export default class AddRecordForm extends Component {
       <div class="item">
         <div class="title">날짜</div>
         <div class="content">
-          <input type="date" name="record_at" value="2020-07-30">
+          <input type="date" name="record_at" value="${todayDate}" required>
         </div>
       </div>
       <div class="item">
         <div class="title">카테고리</div>
         <div class="content">
-          <select name="category">
+          <select name="category" required>
             <option value="0">선택하세요</option>
           </select>
         </div>
@@ -69,7 +145,7 @@ export default class AddRecordForm extends Component {
       <div class="item">
         <div class="title">결제수단</div>
         <div class="content">
-          <select name="paymentMethod">
+          <select name="payment_method" required>
             <option value="0">선택하세요</option>
           </select>
         </div>
@@ -79,13 +155,13 @@ export default class AddRecordForm extends Component {
       <div class="item">
         <div class="title">금액</div>
         <div class="content">
-          <input type="text" name="amount">
+          <input type="text" name="amount" required>
         </div>
       </div>
       <div class="item">
         <div class="title">내용</div>
         <div class="content">
-          <input type="text" name="content">
+          <input type="text" name="content" required>
         </div>
       </div>
     </div>

--- a/client/src/component/RecordGroupList.js
+++ b/client/src/component/RecordGroupList.js
@@ -67,7 +67,7 @@ export default class RecordGroupList extends Component {
       <div class="amount">
         ${amount}원
       </div>
-    </li$>
+    </li>
     `;
   }
 
@@ -105,6 +105,7 @@ export default class RecordGroupList extends Component {
       .map((date) => this.createGroup(date, recordsByDate[date]))}
     `;
 
+    this.element.innerHTML = '';
     const innerNode = templateToElementNodes(template);
     appendChildAll(this.element, innerNode);
   }

--- a/client/src/constant/Event.js
+++ b/client/src/constant/Event.js
@@ -12,10 +12,14 @@ const Event = {
     changeUrl: 'Router:changeUrl',
     onStateChanged: 'Router:onStateChanged',
   },
+  RecordEvent: {
+    create: 'Record:create',
+  },
 };
 
 export const PageEvent = Event.PageEvent;
 export const StoreEvent = Event.StoreEvent;
 export const DateViewEvent = Event.DateViewEvent;
 export const RouterEvent = Event.RouterEvent;
+export const RecordEvent = Event.RecordEvent;
 export default Event;

--- a/client/src/constant/State.js
+++ b/client/src/constant/State.js
@@ -24,26 +24,28 @@ export const notify = (key, data, targetUid = null) => {
     return;
   }
 
-  try {
-    if (targetUid) {
-      Object.values(Store.state[key].listeners).some(
-        ({ eventHandler, uid }) => {
-          if (uid === targetUid) {
-            eventHandler(data);
-            return true;
-          }
-        },
-      );
-
-      return;
-    }
-
-    Object.values(Store.state[key].listeners).forEach(({ eventHandler }) => {
-      eventHandler(data);
+  if (targetUid) {
+    Object.values(Store.state[key].listeners).some(({ eventHandler, uid }) => {
+      if (uid === targetUid) {
+        try {
+          eventHandler(data);
+          return true;
+        } catch (err) {
+          console.error(err);
+        }
+      }
     });
-  } catch (err) {
-    console.error(err);
+
+    return;
   }
+
+  Object.values(Store.state[key].listeners).forEach(({ eventHandler }) => {
+    try {
+      eventHandler(data);
+    } catch (err) {
+      console.error(err);
+    }
+  });
 };
 
 export const clearSubscribers = (key) => {

--- a/client/src/constant/constant.js
+++ b/client/src/constant/constant.js
@@ -3,7 +3,8 @@ export const SERVER = {
 };
 
 export const MESSAGE = {
-  USER_INPUT_ERROR: '요청 값이 이상합니다.',
+  API_USER_INPUT_ERROR: '요청 값이 이상합니다.',
+  FORM_INPUT_EMPTY_ERROR: '모든 값을 입력해주세요.',
 };
 
 export const CATEGORY = {

--- a/client/src/model/apis.js
+++ b/client/src/model/apis.js
@@ -8,15 +8,6 @@ const defaultOptions = (method) => ({
   },
 });
 
-const createQuery = (data) => {
-  return data
-    ? '?' +
-        Object.keys(data)
-          .map((k) => encodeURIComponent(k) + '=' + encodeURIComponent(data[k]))
-          .join('&')
-    : '';
-};
-
 const POST = async (url = '', data) =>
   await fetch(`${serverUrl}${url}`, {
     body: JSON.stringify(data),
@@ -29,8 +20,8 @@ const PUT = async (url = '', data) =>
     ...defaultOptions('PUT'),
   });
 
-const GET = async (url = '', data) =>
-  await fetch(`${serverUrl}${url}${createQuery(data)}`, defaultOptions('GET'));
+const GET = async (url = '') =>
+  await fetch(`${serverUrl}${url}`, defaultOptions('GET'));
 
 const DELETE = async (url = '') =>
   await fetch(`${serverUrl}${url}`, defaultOptions('DELETE'));

--- a/client/src/model/model.js
+++ b/client/src/model/model.js
@@ -45,6 +45,7 @@ export default class Model {
   }
 
   async getRecord(data) {
+    Store.currentPath = data;
     const { year, month } = data;
     await this.fetchDefaultData();
     await this.fetchRecord(year, month);

--- a/client/src/model/model.js
+++ b/client/src/model/model.js
@@ -1,6 +1,6 @@
 import apis from '@src/model/apis.js';
 import { Store } from '@constant/Store.js';
-import { StoreEvent, RouterEvent } from '@constant/Event.js';
+import { StoreEvent, RouterEvent, RecordEvent } from '@constant/Event.js';
 import { subscribe, notify } from '@constant/State.js';
 import { CATEGORY, MESSAGE } from '@constant/constant.js';
 
@@ -24,11 +24,9 @@ const customCategory = {
 
 export default class Model {
   constructor() {
-    subscribe(
-      { uid: Model },
-      RouterEvent.onStateChanged,
-      this.getRecord.bind(this),
-    );
+    const attribute = { uid: Model };
+    subscribe(attribute, RouterEvent.onStateChanged, this.getRecord.bind(this));
+    subscribe(attribute, RecordEvent.create, this.createRecord.bind(this));
   }
 
   convertData(item) {
@@ -38,20 +36,28 @@ export default class Model {
     return { ...item, category, paymentMethod, isIncome };
   }
 
+  async createRecord({ data }) {
+    data.user = Store.user.key;
+    await (await apis.createRecord(data)).json();
+
+    const [year, month] = data.record_at.split('-');
+    notify(RouterEvent.changeUrl, { path: `/record/${year}/${month}` });
+  }
+
   async getRecord(data) {
     const { year, month } = data;
-    await this.setDefaultData();
-    await this.setRecord(year, month);
+    await this.fetchDefaultData();
+    await this.fetchRecord(year, month);
     notify(StoreEvent.onUpdated, { ...Store });
   }
 
-  async setRecord(year, month) {
+  async fetchRecord(year, month) {
     let expenditureSum = 0,
       incomeSum = 0;
 
     const data = await (await apis.findRecord({ year, month })).json();
     if (!data.success) {
-      alert(MESSAGE.USER_INPUT_ERROR);
+      alert(MESSAGE.API_USER_INPUT_ERROR);
       location.href = '/';
     }
 
@@ -68,11 +74,14 @@ export default class Model {
     Store.expenditureSum = expenditureSum;
   }
 
-  async setDefaultData() {
+  async fetchDefaultData() {
     if (Store.paymentMethods) {
       return;
     }
 
+    Store.user = {
+      key: 1,
+    };
     Store.categories = customCategory;
     Store.paymentMethods = customPaymentMethod;
   }

--- a/client/src/stylesheet/component/AddRecordForm.scss
+++ b/client/src/stylesheet/component/AddRecordForm.scss
@@ -42,6 +42,11 @@
     border-bottom: 1px solid $color-black-9;
   }
 
+  select {
+    width: 120px;
+    font-size: 1em;
+  }
+
   .btn_submit {
     width: 100%;
     padding: 10px;

--- a/client/src/stylesheet/component/DateView.scss
+++ b/client/src/stylesheet/component/DateView.scss
@@ -8,9 +8,15 @@
   margin-bottom: 24px;
   user-select: none;
 
-  .month {
+  .current_date {
+    width: 160px;
     font-size: 1.8em;
-    margin: 0 12px;
+    text-align: center;
+  }
+
+  .action {
+    padding: 3px;
+    cursor: pointer;
   }
 
   .arrow {

--- a/client/src/utils/helper.js
+++ b/client/src/utils/helper.js
@@ -4,7 +4,7 @@ export const getCurrentDatetime = () => {
 };
 
 export const dayStr = ['일', '월', '화', '수', '목', '금', '토'];
-export const analyzeDatetime = (datetimeStr) => {
+export const analyzeDatetime = (datetimeStr = '') => {
   const pad = (str) => str.toString().padStart(2, '0');
   const datetime = datetimeStr.replace(/-/g, '/');
 
@@ -35,21 +35,6 @@ export const groupBy = (obj, key) => {
     return pv;
   }, {});
 };
-
-/**
- * Generates a GUID string.
- * @returns {string} The generated GUID.
- * @example af8a8416-6e18-a307-bd9c-f2c947bbb3aa
- * @author Slavik Meltser.
- * @link http://slavik.meltser.info/?p=142
- */
-export function guid() {
-  function _p8(s) {
-    var p = (Math.random().toString(16) + '000000000').substr(2, 8);
-    return s ? '-' + p.substr(0, 4) + '-' + p.substr(4, 4) : p;
-  }
-  return _p8() + _p8(true) + _p8(true) + _p8();
-}
 
 export const getLastDateOfMonth = (year, month) => {
   return new Date(year, month, 0).getDate();

--- a/client/webpack.config.production.js
+++ b/client/webpack.config.production.js
@@ -1,7 +1,22 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.config.common.js');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'production',
   devtool: 'hidden-source-map',
+  optimization: {
+    minimizer: [
+      new UglifyJSPlugin({
+        uglifyOptions: {
+          compress: {
+            drop_console: true,
+          },
+          output: {
+            comments: false,
+          },
+        },
+      }),
+    ],
+  },
 });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6776,6 +6776,11 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+
 serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
@@ -7598,6 +7603,26 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+uglify-js@^3.6.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.1.tgz#dd14767eb7150de97f2573a5ff210db14fffe4ad"
+  integrity sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==
+
+uglifyjs-webpack-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
+  integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
+  dependencies:
+    cacache "^12.0.2"
+    find-cache-dir "^2.1.0"
+    is-wsl "^1.1.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    source-map "^0.6.1"
+    uglify-js "^3.6.0"
+    webpack-sources "^1.4.0"
+    worker-farm "^1.7.0"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/server/api/routes/record.js
+++ b/server/api/routes/record.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 import { wrapAsync } from '@util';
-import { getRecordInMonth } from '@controller/record';
+import { getRecordInMonth, createRecordFromInput } from '@controller/record';
 import { validateRecordParameter } from '@validator/record';
 
 router.get(
@@ -9,5 +9,7 @@ router.get(
   validateRecordParameter,
   wrapAsync(getRecordInMonth),
 );
+
+router.post('/', wrapAsync(createRecordFromInput));
 
 module.exports = router;

--- a/server/controller/record.js
+++ b/server/controller/record.js
@@ -1,4 +1,4 @@
-import { findByYearAndMonth } from '@service/record';
+import { findByYearAndMonth, createRecord } from '@service/record';
 
 const getRecordInMonth = async function (req, res, next) {
   const year = req.params.year;
@@ -13,4 +13,27 @@ const getRecordInMonth = async function (req, res, next) {
   });
 };
 
-export { getRecordInMonth };
+const createRecordFromInput = async function (req, res, next) {
+  const body = req.body;
+  const userKey = body.user;
+  const amount = body.amount;
+  const categoryKey = body.category;
+  const content = body.content;
+  const paymentMethodKey = body.payment_method;
+  const recordAt = body.record_at;
+  const data = {
+    userKey,
+    amount,
+    categoryKey,
+    content,
+    paymentMethodKey,
+    recordAt,
+  };
+
+  const result = await createRecord(data);
+  res.send({
+    success: true,
+  });
+};
+
+export { getRecordInMonth, createRecordFromInput };

--- a/server/model/record.js
+++ b/server/model/record.js
@@ -1,11 +1,35 @@
 import Pool from './pool';
+import { getCurrentDateTime } from '@util/index';
 
+const INSERT_RECORD = `
+  INSERT INTO MONEY_RECORD
+  (user_key, category_key, payment_method_key, record_at, amount, content, created_at, edited_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+`;
 const FIND_BY_YEAR_AND_MONTH =
   'SELECT * FROM MONEY_RECORD WHERE RECORD_AT BETWEEN ? AND ? ORDER BY RECORD_AT, `KEY`';
 const GET_RECENT_UPDATED_RECORD_BY_YEAR_AND_MONTH =
   'SELECT EDITED_AT FROM MONEY_RECORD WHERE RECORD_AT BETWEEN ? AND ? ORDER BY EDITED_AT DESC LIMIT 1';
+
 export default class Record {
   constructor() {}
+
+  async createRecord(data) {
+    const connection = await Pool.getConnection();
+    const currentDatetime = getCurrentDateTime();
+    const [rows] = await connection.execute(INSERT_RECORD, [
+      data.userKey,
+      data.categoryKey,
+      data.paymentMethodKey,
+      data.recordAt,
+      data.amount,
+      data.content,
+      currentDatetime,
+      currentDatetime,
+    ]);
+    connection.release();
+    return rows;
+  }
 
   async findByYearAndMonth(year, month) {
     const connection = await Pool.getConnection();

--- a/server/service/record.js
+++ b/server/service/record.js
@@ -13,8 +13,13 @@ async function getRecentUpdatedDate(year, month) {
   return record[0].EDITED_AT;
 }
 
+async function createRecord(data) {
+  const record = await recordModel.createRecord(data);
+  return record[0];
+}
+
 function changeFormatOfRecord(records) {
   return records;
 }
 
-export { findByYearAndMonth, getRecentUpdatedDate };
+export { findByYearAndMonth, getRecentUpdatedDate, createRecord };

--- a/server/util/index.js
+++ b/server/util/index.js
@@ -1,7 +1,13 @@
+import { format } from 'date-fns';
+
 function wrapAsync(fn) {
   return function (req, res, next) {
     fn(req, res, next).catch(next);
   };
 }
 
-export { wrapAsync };
+function getCurrentDateTime() {
+  return format(new Date(), 'yyyy-MM-dd HH:mm:ss');
+}
+
+export { wrapAsync, getCurrentDateTime };

--- a/server/validator/common.js
+++ b/server/validator/common.js
@@ -1,23 +1,27 @@
 import { parseISO, isValid } from 'date-fns';
 
+const validateNumber = function (value, { min = null, max = null }) {
+  if (isNaN(value)) {
+    return [true, 'value is must be number'];
+  }
+  if ((min != null && value < min) || (max != null && value > max)) {
+    return [true, 'value is out of range'];
+  }
+  return [false];
+};
+
 const validateYear = function (year) {
   if (isNaN(year)) {
     return [true, 'year is must be number'];
   }
-  if (year < 1900 || year > new Date().getFullYear() || year.length < 4) {
+  if (year < 1900 || year > new Date().getFullYear() + 30 || year.length < 4) {
     return [true, 'year is out of range'];
   }
   return [false];
 };
 
 const validateMonth = function (month) {
-  if (isNaN(month)) {
-    return [true, 'month is must be number'];
-  }
-  if (month < 1 || month > 12) {
-    return [true, 'month is out of range'];
-  }
-  return [false];
+  return validateNumber(month, { min: 1, max: 12 });
 };
 
 const validateDate = function (date) {


### PR DESCRIPTION
> 내역 등록 (API 구현도 포함)

## 체크리스트

> 작성자, 리뷰어 모두가 확인해야할 사항들 입니다.

- [o] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [o] 작성한 코드에 대해 모두 이해하였는지 확인
- [o] 관련된 label 추가했는지 확인

## 관련 이슈

- #18 
- #19 
- resolve #29 

## 설명

### 1. 내용 등록 API
- 빠른 구현을 위해, validator를 제외하고 개발함

### 2. 내역 등록
- 수입/지출 선택에 따라, 카테고리 데이터도 갱신됨
- 현재, 입력 폼 컴포넌트가 지출수단/카테고리 정보를 저장하는 구조로 구현
(수입/지출을 변경할 때 데이터가 바뀌는데, 저장하지 않으면 매번 모델에게 요청함)
- 입력 폼 컴포넌트가 데이터 notify하면 API 통신함
- 입력한 데이터의 연월로 자동 이동시킴

### 3. 월 표시/이동
- 현재 URL 상태 기준으로 월 표시/이동 구현

### 4. 기타
- validator 함수 분리 (validateNumber로 만들면, 재활용할 수 있음)
- 웹팩 production 빌드 옵션 추가 (uglifyjs)
- notify 내 에러 핸들러 추가
- 미사용 유틸 함수 제거 (fetch, guid)